### PR TITLE
added compile.spec for pyinstaller

### DIFF
--- a/compile.spec
+++ b/compile.spec
@@ -1,0 +1,41 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(['main.py'],
+             pathex=['C:\\msys64\\home\\hussein\\Masendor'],
+             binaries=[],
+             datas=[
+                ('data', 'data'),
+                ('profile', 'profile'),
+                ('configuration.ini', 'configuration.ini'),
+                ('gamestate.png', 'gamestate.png'),
+                ('preview.png', 'preview.png'),
+                ('pygamelogo.gif', 'pygamelogo.gif'),
+                ('battle ui manual.png', 'battle ui manual.png')
+             ],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='masendor',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=False )


### PR DESCRIPTION
add compile.spec for making compiling the game to one executable without any dependencies with one easy command

pyinstaller compile.spec

it produces a binary using pyinstaller without any other dependencies just run dist/masendor.exe and done