### PR TITLE
Attempt optimize draw map

### DIFF
--- a/tests/test_battlemap.py
+++ b/tests/test_battlemap.py
@@ -2,11 +2,13 @@ import pygame
 import os
 
 
-def compare_surfaces(surface_a, surface_b):
-    if surface_a.get_size() != surface_b.get_size(): return False
+def compare_surfaces(surface_a, surface_b, error_margin = 0):
+    if surface_a.get_size() != surface_b.get_size():
+        return False
     for x in range(surface_a.get_size()[0]):
         for y in range(surface_a.get_size()[1]):
-            if surface_a.get_at((x, y)) != surface_b.get_at((x, y)): return False
+            if sum((abs(surface_a.get_at((x,y))[i]-surface_b.get_at((x,y))[i]) for i in range(3))) > error_margin: 
+                return False
     return True
 
 
@@ -59,4 +61,8 @@ def test_recolour_man_and_build_move_and_def_arrays():
         battle=mb,
     )
 
-    assert compare_surfaces(battle_map.image, pygame.image.load(os.path.join(main_dir, "tests/map1.png")))
+    assert compare_surfaces(
+        battle_map.image,
+        pygame.image.load(os.path.join(main_dir, "tests/map1.png")),
+        error_margin=3
+    )


### PR DESCRIPTION
### It is a bit faster now:

`OLD: Loading draw map...  DONE (3.1503758430480957s)`

`NEW: Loading draw map...  DONE (2.426858425140381s)`

It could be even faster if we recreate all base data of the height map to grey scale (but we will lose that time when we need to create red-alpha height maps from that grey scale ;) But the red-alpha height map could only be created when requested for it so it will not be needed during load)

### but is not 100% the same as before

To prove that nothing breaks I write tests. This test was to make sure it gave the same output.
Notice that I added something called error_margin. If some error margin the test can pass as long as it close enough

```
def compare_surfaces(surface_a, surface_b, error_margin = 0):
    if surface_a.get_size() != surface_b.get_size():
        return False
    for x in range(surface_a.get_size()[0]):
        for y in range(surface_a.get_size()[1]):
            if sum((abs(surface_a.get_at((x,y))[i]-surface_b.get_at((x,y))[i]) for i in range(3))) > error_margin:
                return False
    return True
```


As you can see the error_margin to make test pass was set to 3. Since we dealing with RGB values is that it only allows for "one" brightness in difference is allowed. Hope that is ok.


```
assert compare_surfaces(
    battle_map.image,
    pygame.image.load(os.path.join(main_dir, "tests/map1.png")),
    error_margin=3
)
```

The reason for this error margin was it was hard to divide brightness with 20 using BLEND.

A half second might not be that much, it so most likely less on faster computer than mine. As soon as we can get rid of that for loop through every pixels I think it will be much faster. There are still logic left that is depended on it.

